### PR TITLE
Update goatrider.py

### DIFF
--- a/goatrider.py
+++ b/goatrider.py
@@ -359,7 +359,10 @@ def parse_ip_file( fileinput ):
     len_cl = len(content_lines)
     max_lines = MAX_LINES
     if len_cl < MAX_LINES:
-        max_lines = len_cl/CPU_CORES 
+        if len_cl/CPU_CORES < 1:
+            max_lines = 1
+        else:
+            max_lines = len_cl/CPU_CORES 
     tmp = []
     for index in range( 0, len_cl, max_lines):
         if index+max_lines > len_cl:


### PR DESCRIPTION
Fixed issue in which testing with a small IP or Host list would result in a 0 for max_lines/CPU_CORES causing the range (previously line 364) step to be set to 0.